### PR TITLE
Fixing execution of quickstart inside a docker container locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ RUN npm --quiet set progress=false \
 # Next, copy the remaining files and directories with the source code.
 # Since we do this after NPM install, quick build will be really fast
 # for most source file changes.
-# Note that because we are copying also apify_storage dir we need to set
-# an correct owner to make it writable.
+# Note that because we are also copying the "apify_storage" directory, we
+# need to set a correct owner to make it writable, for local runs in Docker.
 COPY --chown=myuser . ./
 
 # Optionally, specify how to launch the source code of your actor.

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,9 @@ RUN npm --quiet set progress=false \
 # Next, copy the remaining files and directories with the source code.
 # Since we do this after NPM install, quick build will be really fast
 # for most source file changes.
-COPY . ./
+# Note that because we are copying also apify_storage dir we need to set
+# an correct owner to make it writable.
+COPY --chown=myuser . ./
 
 # Optionally, specify how to launch the source code of your actor.
 # By default, Apify's base Docker images define the CMD instruction


### PR DESCRIPTION
This fixes the problem somebody reported. If you follow the README to build container locally then apify_storage dir is copied there but docker `COPY` command copies it with `root` ownership` so it's not writable then for user under which the `CMD` is executed.